### PR TITLE
Refactor API routes into blueprints

### DIFF
--- a/ride-it-api/app.py
+++ b/ride-it-api/app.py
@@ -1,121 +1,15 @@
-from flask import Flask, jsonify, request
+from flask import Flask
+
+from events import events_bp
+from auth import auth_bp
+from notify import notify_bp
 
 app = Flask(__name__)
 
-# in-memory event store
-events = []
-event_id_counter = 1
-
-class NotificationHub:
-    def send_email(self, to, subject, body):
-        print(f"Sending email to {to} with subject '{subject}'")
-
-    def send_sms(self, to, message):
-        print(f"Sending SMS to {to}: {message}")
-
-    def send_whatsapp(self, to, message):
-        print(f"Sending WhatsApp to {to}: {message}")
-
-notification_hub = NotificationHub()
-
-@app.route("/events", methods=["POST"])
-def create_event():
-    global event_id_counter
-    data = request.json or {}
-    event = {
-        "id": event_id_counter,
-        "name": data.get("name"),
-        "status": "upcoming",
-        "members": []
-    }
-    events.append(event)
-    event_id_counter += 1
-    return jsonify(event), 201
-
-@app.route("/events/<int:event_id>", methods=["PUT"])
-def edit_event(event_id):
-    data = request.json or {}
-    for event in events:
-        if event["id"] == event_id and event["status"] != "deleted":
-            event.update({k: v for k, v in data.items() if k in ["name", "status"]})
-            return jsonify(event)
-    return jsonify({"error": "Event not found"}), 404
-
-@app.route("/events/<int:event_id>", methods=["DELETE"])
-def delete_event(event_id):
-    for event in events:
-        if event["id"] == event_id and event["status"] != "deleted":
-            event["status"] = "deleted"
-            return jsonify({"message": "Event deleted"})
-    return jsonify({"error": "Event not found"}), 404
-
-@app.route("/events/my")
-def my_events():
-    user = request.args.get("user")
-    user_events = [e for e in events if user in e["members"] and e["status"] != "deleted"]
-    return jsonify(user_events)
-
-@app.route("/events/in-progress")
-def in_progress_events():
-    return jsonify([e for e in events if e["status"] == "in_progress"])
-
-@app.route("/events/upcoming")
-def upcoming_events():
-    return jsonify([e for e in events if e["status"] == "upcoming"])
-
-@app.route("/events/deleted")
-def deleted_events():
-    return jsonify([e for e in events if e["status"] == "deleted"])
-
-@app.route("/events/<int:event_id>/join", methods=["POST"])
-def join_event(event_id):
-    user = (request.json or {}).get("user")
-    for event in events:
-        if event["id"] == event_id and event["status"] != "deleted":
-            if user not in event["members"]:
-                event["members"].append(user)
-            return jsonify(event)
-    return jsonify({"error": "Event not found"}), 404
-
-@app.route("/events/<int:event_id>/unjoin", methods=["POST"])
-def unjoin_event(event_id):
-    user = (request.json or {}).get("user")
-    for event in events:
-        if event["id"] == event_id and user in event["members"]:
-            event["members"].remove(user)
-            return jsonify(event)
-    return jsonify({"error": "Event not found"}), 404
-
-@app.route("/events/<int:event_id>/members/<int:user_id>", methods=["DELETE"])
-def remove_member(event_id, user_id):
-    for event in events:
-        if event["id"] == event_id and user_id in event["members"]:
-            event["members"].remove(user_id)
-            return jsonify({"message": "Member removed"})
-    return jsonify({"error": "Event or member not found"}), 404
-
-@app.route("/auth/google")
-def google_sign_in():
-    # placeholder for Google sign in logic
-    return jsonify({"message": "Signed in with Google"})
-
-@app.route("/notify/email", methods=["POST"])
-def notify_email():
-    data = request.json or {}
-    notification_hub.send_email(data.get("to"), data.get("subject"), data.get("body"))
-    return jsonify({"message": "Email sent"})
-
-@app.route("/notify/sms", methods=["POST"])
-def notify_sms():
-    data = request.json or {}
-    notification_hub.send_sms(data.get("to"), data.get("message"))
-    return jsonify({"message": "SMS sent"})
-
-@app.route("/notify/whatsapp", methods=["POST"])
-def notify_whatsapp():
-    data = request.json or {}
-    notification_hub.send_whatsapp(data.get("to"), data.get("message"))
-    return jsonify({"message": "WhatsApp message sent"})
+# register blueprints
+app.register_blueprint(events_bp)
+app.register_blueprint(auth_bp)
+app.register_blueprint(notify_bp)
 
 if __name__ == "__main__":
     app.run()

--- a/ride-it-api/auth.py
+++ b/ride-it-api/auth.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, jsonify
+
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/auth/google')
+def google_sign_in():
+    # placeholder for Google sign in logic
+    return jsonify({'message': 'Signed in with Google'})

--- a/ride-it-api/events.py
+++ b/ride-it-api/events.py
@@ -1,0 +1,94 @@
+from flask import Blueprint, jsonify, request
+
+
+events_bp = Blueprint('events', __name__)
+
+# in-memory event store
+events = []
+event_id_counter = 1
+
+
+@events_bp.route('/events', methods=['POST'])
+def create_event():
+    global event_id_counter
+    data = request.json or {}
+    event = {
+        'id': event_id_counter,
+        'name': data.get('name'),
+        'status': 'upcoming',
+        'members': []
+    }
+    events.append(event)
+    event_id_counter += 1
+    return jsonify(event), 201
+
+
+@events_bp.route('/events/<int:event_id>', methods=['PUT'])
+def edit_event(event_id):
+    data = request.json or {}
+    for event in events:
+        if event['id'] == event_id and event['status'] != 'deleted':
+            event.update({k: v for k, v in data.items() if k in ['name', 'status']})
+            return jsonify(event)
+    return jsonify({'error': 'Event not found'}), 404
+
+
+@events_bp.route('/events/<int:event_id>', methods=['DELETE'])
+def delete_event(event_id):
+    for event in events:
+        if event['id'] == event_id and event['status'] != 'deleted':
+            event['status'] = 'deleted'
+            return jsonify({'message': 'Event deleted'})
+    return jsonify({'error': 'Event not found'}), 404
+
+
+@events_bp.route('/events/my')
+def my_events():
+    user = request.args.get('user')
+    user_events = [e for e in events if user in e['members'] and e['status'] != 'deleted']
+    return jsonify(user_events)
+
+
+@events_bp.route('/events/in-progress')
+def in_progress_events():
+    return jsonify([e for e in events if e['status'] == 'in_progress'])
+
+
+@events_bp.route('/events/upcoming')
+def upcoming_events():
+    return jsonify([e for e in events if e['status'] == 'upcoming'])
+
+
+@events_bp.route('/events/deleted')
+def deleted_events():
+    return jsonify([e for e in events if e['status'] == 'deleted'])
+
+
+@events_bp.route('/events/<int:event_id>/join', methods=['POST'])
+def join_event(event_id):
+    user = (request.json or {}).get('user')
+    for event in events:
+        if event['id'] == event_id and event['status'] != 'deleted':
+            if user not in event['members']:
+                event['members'].append(user)
+            return jsonify(event)
+    return jsonify({'error': 'Event not found'}), 404
+
+
+@events_bp.route('/events/<int:event_id>/unjoin', methods=['POST'])
+def unjoin_event(event_id):
+    user = (request.json or {}).get('user')
+    for event in events:
+        if event['id'] == event_id and user in event['members']:
+            event['members'].remove(user)
+            return jsonify(event)
+    return jsonify({'error': 'Event not found'}), 404
+
+
+@events_bp.route('/events/<int:event_id>/members/<int:user_id>', methods=['DELETE'])
+def remove_member(event_id, user_id):
+    for event in events:
+        if event['id'] == event_id and user_id in event['members']:
+            event['members'].remove(user_id)
+            return jsonify({'message': 'Member removed'})
+    return jsonify({'error': 'Event or member not found'}), 404

--- a/ride-it-api/notify.py
+++ b/ride-it-api/notify.py
@@ -1,0 +1,39 @@
+from flask import Blueprint, jsonify, request
+
+
+notify_bp = Blueprint('notify', __name__)
+
+
+class NotificationHub:
+    def send_email(self, to, subject, body):
+        print(f"Sending email to {to} with subject '{subject}'")
+
+    def send_sms(self, to, message):
+        print(f"Sending SMS to {to}: {message}")
+
+    def send_whatsapp(self, to, message):
+        print(f"Sending WhatsApp to {to}: {message}")
+
+
+notification_hub = NotificationHub()
+
+
+@notify_bp.route('/notify/email', methods=['POST'])
+def notify_email():
+    data = request.json or {}
+    notification_hub.send_email(data.get('to'), data.get('subject'), data.get('body'))
+    return jsonify({'message': 'Email sent'})
+
+
+@notify_bp.route('/notify/sms', methods=['POST'])
+def notify_sms():
+    data = request.json or {}
+    notification_hub.send_sms(data.get('to'), data.get('message'))
+    return jsonify({'message': 'SMS sent'})
+
+
+@notify_bp.route('/notify/whatsapp', methods=['POST'])
+def notify_whatsapp():
+    data = request.json or {}
+    notification_hub.send_whatsapp(data.get('to'), data.get('message'))
+    return jsonify({'message': 'WhatsApp message sent'})


### PR DESCRIPTION
## Summary
- separate routes into `events.py`, `auth.py`, and `notify.py`
- register these blueprints in `app.py`

## Testing
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851afb1ebfc8328b4221aaaac69e724