### PR TITLE
Add neomorphic layout with sticky header

### DIFF
--- a/ride-it-web/src/App.tsx
+++ b/ride-it-web/src/App.tsx
@@ -1,43 +1,24 @@
-import { Footer } from './components/Footer';
-import { HeaderNavigation } from './components/HeaderNavigation';
-import { Tabs } from './components/Tabs';
+import { Footer } from './components/Footer'
+import { HeaderNavigation } from './components/HeaderNavigation'
+import { Tabs } from './components/Tabs'
 import { UseHelmet } from './hooks/UseHelmet'
 import { Rides } from './pages/Rides'
-function App() {
-  UseHelmet("Ride it");
-  return (
-    <>
-    <HeaderNavigation />
-     <div style={{
-      marginLeft: 600,
-      marginRight: 600,
-      height: 'auto',
-      padding: 20,
-      border: '1px solid darkgray',
-      width: 'auto',
-      marginTop: 50,
-      position: 'relative',
-      borderRadius: '10px'
-    }}>
-     <Rides />
-    </div>
-    <div style={{
-      marginLeft: 600,
-      marginRight: 600,
-      height: 'auto',
-      padding: 20,
-      border: '1px solid darkgray',
-      width: 'auto',
-      marginTop: 20,
-      position: 'relative',
-      borderRadius: '10px'
-    }}>
-     <div><Tabs /></div>
-    </div>
 
-    <Footer />
-    </>
-   
+function App() {
+  UseHelmet('Ride it')
+  return (
+    <div className="neo-layout">
+      <HeaderNavigation />
+      <main className="neo-main">
+        <div className="neo-container" style={{ margin: '2rem auto', maxWidth: '600px' }}>
+          <Rides />
+        </div>
+        <div className="neo-container" style={{ margin: '2rem auto', maxWidth: '600px' }}>
+          <Tabs />
+        </div>
+      </main>
+      <Footer />
+    </div>
   )
 }
 

--- a/ride-it-web/src/components/HeaderNavigation.tsx
+++ b/ride-it-web/src/components/HeaderNavigation.tsx
@@ -1,6 +1,6 @@
 export const HeaderNavigation = () => {
   return (
-    <header className="neo-header">
+    <header className="neo-header neo-sticky">
       <h2>Ride It</h2>
     </header>
   )

--- a/ride-it-web/src/styles/neomorphism.css
+++ b/ride-it-web/src/styles/neomorphism.css
@@ -103,3 +103,19 @@
               -8px -8px 16px var(--neo-shadow-light);
   padding: 1rem;
 }
+
+.neo-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.neo-main {
+  flex: 1;
+}
+
+.neo-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- revamp layout in `App.tsx` using neomorphic container classes
- make header sticky
- keep footer pinned to bottom by using a flex layout
- extend neomorphism styles with layout helpers

## Testing
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_6851b325c55c83288d39d965b0d38ddc